### PR TITLE
Fix encoding for extra comic info

### DIFF
--- a/scripts/build_site.py
+++ b/scripts/build_site.py
@@ -729,11 +729,11 @@ def get_extra_comic_info(folder_name: str, comic_info: RawConfigParser):
     del comic_info["Pages"]
     # Delete "Links Bar" from original if the extra comic's info has that section defined
     extra_comic_info = RawConfigParser()
-    extra_comic_info.read(f"your_content/{folder_name}/comic_info.ini")
+    extra_comic_info.read(f"your_content/{folder_name}/comic_info.ini", encoding="utf-8")
     if extra_comic_info.has_section("Links Bar"):
         del comic_info["Links Bar"]
     # Read the extra comic info in again, to merge with the original comic info
-    comic_info.read(f"your_content/{folder_name}/comic_info.ini")
+    comic_info.read(f"your_content/{folder_name}/comic_info.ini", encoding="utf-8")
     return comic_info
 
 


### PR DESCRIPTION
This fixes an encoding issue while reading the extra comic info.


To reproduce, create an extra comic directory containing a `comic_info.ini` with, for example turkish, links.
```
[Pages]
; index = Gallery of happy comic_git users
latest = Latest
archive = Arşiv
infinite_scroll = Sonsuz kaydırma
comic = Çizgi roman

[Links Bar]
Ana Sayfa = /
Arşiv = /turkish/archive/
Çizgi roman = /turkish/comic/
Sonsuz kaydırma = /turkish/infinite_scroll/
Deutsch = /comic
```
Before:
<img width="708" height="65" alt="image" src="https://github.com/user-attachments/assets/7119a2e0-ba0a-443b-9581-361c1032b6dc" />

After:
<img width="643" height="63" alt="image" src="https://github.com/user-attachments/assets/2e7f8d37-6e1f-478a-97d8-a62d52858091" />
